### PR TITLE
Release: 2.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,5 @@ build/
 pubspec.lock
 example/ios/Podfile.lock
 mdsflutter.iml
-example/android/libs/*
+example/android/libs/*.aar
 .vscode/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.1-rc1
+
+* Bugfix: Cocoapods can't access remote repository (Issue #13)
+* Bugfix: The MdsAsync API is not documented (Issue #14)
+
 ## 2.1.0
 
 * Prevent duplicate connections to same device

--- a/README.md
+++ b/README.md
@@ -16,7 +16,18 @@ This is the development version for a new Async API. Please give any opinions, s
   pod 'Movesense', :git => 'ssh://git@altssh.bitbucket.org:443/movesense/movesense-mobile-lib.git'
   ```
 
-2. Remove "use_frameworks!" from your Podfile so that libmds.a can be used correctly.
+2. Set up your ios/Podfile as follows:
+```
+target 'Runner' do
+  use_modular_headers!
+  use_frameworks! :linkage => :static
+
+  pod 'Movesense', :git => 'https://bitbucket.org/movesense/movesense-mobile-lib.git'
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+```
+so that MDS library is linked correctly. If you need to use frameworks that demand dynamic linking, [follow the instructions here](https://bitbucket.org/movesense/movesense-mobile-lib/issues/119/cannot-use-health-and-mdsflutter-depending).
 
 #### Android
 

--- a/example/README.md
+++ b/example/README.md
@@ -14,3 +14,8 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter, view our
 [online documentation](https://flutter.dev/docs), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Integrating Android MDS ##
+
+Download the latest MDS library (libmds-xx.yy.zz-release.aar) for Android from [Movesense Mobile Lib repository](https://bitbucket.org/movesense/movesense-mobile-lib/src/master/android/Movesense/), and copy it into example/android/libs folder.
+

--- a/example/android/libs/CopyMDSLibraryForAndroidHere.txt
+++ b/example/android/libs/CopyMDSLibraryForAndroidHere.txt
@@ -1,0 +1,1 @@
+Download the latest MDS library (libmds-xx.yy.zz-release.aar) for Android from https://bitbucket.org/movesense/movesense-mobile-lib/src/master/android/Movesense/, and copy it here.

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -31,7 +31,7 @@ target 'Runner' do
   use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
-  pod 'Movesense', :git => 'ssh://git@altssh.bitbucket.org:443/movesense/movesense-mobile-lib.git'
+  pod 'Movesense', :git => 'https://bitbucket.org/movesense/movesense-mobile-lib.git'
 end
 
 post_install do |installer|

--- a/lib/Mds.dart
+++ b/lib/Mds.dart
@@ -151,29 +151,9 @@ class MdsAsync {
     MdsImpl().stopScan();
   }
 
-  /// Try to connect to a Movesense device with the given address. Address is
-  /// Bluetooth MAC address for Android devices and UUID for iOS devices. When
-  /// connection is established, onConnected is called with the device serial.
-  /// onDisconnected is called when device disconnects. onConnectionError is
-  /// called when an error occurs during connection attempt.
-  ///
-  /// Note: If you need DeviceInfo upon connection, you should manually
-  /// subscribe to "MDS/ConnectedDevices" to get detailed device information
-  /// upon connection.
-  // static void connect(String address,
-  //     void Function(String) onConnected,
-  //     void Function() onDisconnected,
-  //     void Function() onConnectionError) {
-  //   MdsImpl().connect(address, onConnected, onDisconnected, onConnectionError);
-  // }
-
-  // /// Disconnect from the device with the given address.
-  // static void disconnect(String address) {
-  //   MdsImpl().disconnect(address);
-  // }
-
   /// Make an async GET request for a resource. uri must include "suunto://" prefix
   /// and device serial if needed. contract must be a json string.
+  /// Returns a Future that completes with the response data in json format.
   static Future<dynamic> get(String uri, String contract) {
     final mdscompleter = Completer<dynamic>();
 
@@ -192,6 +172,7 @@ class MdsAsync {
 
   /// Make a PUT request for a resource. uri must include "suunto://" prefix
   /// and device serial if needed. contract must be a json string.
+  /// Returns a Future that completes with the response data in json format.
   static Future<dynamic> put(String uri, String contract) {
     final mdscompleter = Completer<dynamic>();
 
@@ -208,10 +189,8 @@ class MdsAsync {
   }
 
   /// Make a POST request for a resource. uri must include "suunto://" prefix
-  /// and device serial if needed. contract must be a json string. If the
-  /// request is successful, onSuccess is called with response data in json
-  /// string format, and status code. Upon error, onError is called with reason
-  /// and status code.
+  /// and device serial if needed. contract must be a json string.
+  /// Returns a Future that completes with the response data in json format.
   static Future<dynamic> post(String uri, String contract) {
     final mdscompleter = Completer<dynamic>();
 
@@ -226,10 +205,8 @@ class MdsAsync {
   }
 
   /// Make a DEL request for a resource. uri must include "suunto://" prefix
-  /// and device serial if needed. contract must be a json string. If the
-  /// request is successful, onSuccess is called with response data in json
-  /// string format, and status code. Upon error, onError is called with reason
-  /// and status code.
+  /// and device serial if needed. contract must be a json string.
+  /// Returns a Future that completes with the response data in json format.
   static Future<dynamic> del(String uri, String contract) {
     final mdscompleter = Completer<dynamic>();
 
@@ -244,26 +221,10 @@ class MdsAsync {
   }
 
   /// Make a SUBSCRIPTION request for a resource. uri must include "suunto://"
-  /// prefix and device serial if needed. contract must be a json string. If the
-  /// request is successful, onSuccess is called with response data in json
-  /// string format, and status code. Upon error, onError is called with reason
-  /// and status code. When there is a notification, onNotification is called
-  /// with notification data, which is in json string format.
-  /// onSubscriptionError is called when an error occurs with subscription, with
-  /// reason and error status code.
+  /// prefix and device serial if needed. contract must be a json string.
   ///
-  /// This call returns a subscription id. It must be held and used when
-  /// unsubscribing.
-  // static int subscribe(
-  //     String uri,
-  //     String contract,
-  //     void Function(String, int) onSuccess,
-  //     void Function(String, int) onError,
-  //     void Function(String) onNotification,
-  //     void Function(String, int) onSubscriptionError) {
-  //   return MdsImpl().subscribe(
-  //       uri, contract, onSuccess, onError, onNotification, onSubscriptionError);
-  // }
+  /// This call returns a Stream which will emit the notification data.
+  /// Unsubscribing the Stream will automatically unsubscribe from the subscription.
   static Stream<dynamic> subscribe(String uri, String contract) {
     final controller = StreamController<dynamic>();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   that is used for communicating with Movesense devices. This plugin was createad originally by 
   Tugberk Agdokan and it used to be at https://github.com/tugberka/mdsflutter.
 
-version: 2.1.1-rc1
+version: 2.1.1
 homepage: https://github.com/petri-lipponen-movesense/mdsflutter
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   that is used for communicating with Movesense devices. This plugin was createad originally by 
   Tugberk Agdokan and it used to be at https://github.com/tugberka/mdsflutter.
 
-version: 2.1.0
+version: 2.1.1-rc1
 homepage: https://github.com/petri-lipponen-movesense/mdsflutter
 
 environment:


### PR DESCRIPTION
- make sure mdsflutter is ready for MDS 3.27.0
- Remove included MDS .aar for Android, and replace with instructions
- Fix: Bad instructions in README.md
- Fix: Cocoapods can't access remote repository (Issue https://github.com/petri-lipponen-movesense/mdsflutter/issues/13)
- Fix:  The MdsAsync API is not documented (Issue https://github.com/petri-lipponen-movesense/mdsflutter/issues/14)