### PR TITLE
Fix/namespace not defined

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,10 @@ apply plugin: 'kotlin-android'
 apply plugin: 'com.google.protobuf'
 
 android {
+    kotlinOptions {
+        jvmTarget = "1.8" // or "11" if your project requires it
+    }
+    namespace 'com.tugberka.mdsflutter'
     compileSdkVersion 29
 
     sourceSets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ apply plugin: 'com.google.protobuf'
 
 android {
     kotlinOptions {
-        jvmTarget = "1.8" // or "11" if your project requires it
+        jvmTarget = "1.8"
     }
     namespace 'com.tugberka.mdsflutter'
     compileSdkVersion 29

--- a/example/lib/AppModel.dart
+++ b/example/lib/AppModel.dart
@@ -65,7 +65,7 @@ class AppModel extends ChangeNotifier {
         device.address!,
         (serial) => _onDeviceMdsConnected(device.address, serial),
         () => _onDeviceDisconnected(device.address),
-        () => _onDeviceConnectError(device.address));
+        (_) => _onDeviceConnectError(device.address));
   }
 
   void disconnectFromDevice(Device device) {


### PR DESCRIPTION
This pr aims to fix the followin issues:
- Error that occurs with recent Java and Gradle versions where namespace option is not defined in build.gradle.
- Change outdated code in example app.