### PR TITLE
chore: bump protobuf version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  protobuf: ^2.1.0
+  protobuf: '>=2.1.0 <4.0.0'
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Relax constraint on `protobuf` dependency to support latest stable version.