### PR TITLE
Feature: Make sensors in DFU Mode discoverable

### DIFF
--- a/android/src/main/kotlin/com/tugberka/mdsflutter/MdsflutterPlugin.kt
+++ b/android/src/main/kotlin/com/tugberka/mdsflutter/MdsflutterPlugin.kt
@@ -131,7 +131,8 @@ class MdsflutterPlugin: FlutterPlugin, MethodCallHandler {
         } ?: result.notImplemented()
       }
       "startScan" -> {
-        startScan()
+        val includeDfu = call.argument<Boolean>("includeDfu")
+        startScan(includeDfu ?: false)
         result.success(null)
       }
       "stopScan" -> {
@@ -164,11 +165,16 @@ class MdsflutterPlugin: FlutterPlugin, MethodCallHandler {
     mds = null
   }
 
-  private fun startScan() {
+  private fun startScan(includeDfu: Boolean) {
     val scanFilter1 = ScanFilter.Builder().setServiceUuid(ParcelUuid(UUID.fromString("61353090-8231-49cc-b57a-886370740041"))).build()
     val scanFilter2 = ScanFilter.Builder().setServiceUuid(ParcelUuid(UUID.fromString("0000FDF3-0000-1000-8000-00805F9B34FB"))).build()
+    val dfuScanFilter = ScanFilter.Builder().setServiceUuid(ParcelUuid(UUID.fromString("0000FE59-0000-1000-8000-00805F9B34FB"))).build()
     val settings = ScanSettings.Builder().build()
-    bluetoothAdapter!!.bluetoothLeScanner.startScan(listOf(scanFilter1, scanFilter2), settings, scanCb)
+    val scanFilters = mutableListOf(scanFilter1, scanFilter2)
+    if (includeDfu) {
+      scanFilters.add(dfuScanFilter)
+    }
+    bluetoothAdapter!!.bluetoothLeScanner.startScan(scanFilters, settings, scanCb)
   }
 
   private fun stopScan() {

--- a/example/lib/AppModel.dart
+++ b/example/lib/AppModel.dart
@@ -27,7 +27,7 @@ class AppModel extends ChangeNotifier {
     _onDeviceDisonnectedCb = cb;
   }
 
-  void startScan() {
+  void startScan([bool includeDfu = false]) {
     _deviceList.forEach((device) {
       if (device.connectionStatus == DeviceConnectionStatus.CONNECTED) {
         disconnectFromDevice(device);
@@ -44,7 +44,7 @@ class AppModel extends ChangeNotifier {
           _deviceList.add(device);
           notifyListeners();
         }
-      });
+      }, includeDfu: includeDfu);
       _isScanning = true;
       notifyListeners();
     } on PlatformException {

--- a/example/lib/ScanWidget.dart
+++ b/example/lib/ScanWidget.dart
@@ -14,6 +14,7 @@ class ScanWidget extends StatefulWidget {
 
 class _ScanWidgetState extends State<ScanWidget> {
   late AppModel model;
+  bool _includeDfu = false;
 
   @override
   void initState() {
@@ -61,7 +62,7 @@ class _ScanWidgetState extends State<ScanWidget> {
     if (model.isScanning) {
       model.stopScan();
     } else {
-      model.startScan();
+      model.startScan(_includeDfu);
     }
   }
 
@@ -76,6 +77,15 @@ class _ScanWidgetState extends State<ScanWidget> {
             return Column(
               mainAxisSize: MainAxisSize.min,
               children: <Widget>[
+                SwitchListTile(
+                  title: const Text('Include DFU'),
+                  value: _includeDfu,
+                  onChanged: (bool value) {
+                    setState(() {
+                      _includeDfu = value;
+                    });
+                  },
+                ),
                 ElevatedButton(
                   onPressed: onScanButtonPressed,
                   child: Text(model.scanButtonText),

--- a/ios/Classes/BleController.swift
+++ b/ios/Classes/BleController.swift
@@ -5,7 +5,7 @@ import CoreBluetooth
 final class BleController: NSObject, CBCentralManagerDelegate {
     static let SCAN_TIMEOUT = 60.0
     let MOVESENSE_SERVICES = [CBUUID(string: "61353090-8231-49cc-b57a-886370740041"), CBUUID(string: "0000FDF3-0000-1000-8000-00805F9B34FB")]
-    
+        let MOVESENSE_DFU_SERVICE = CBUUID(string: "0000FE59-0000-1000-8000-00805F9B34FB")
     private var centralManager : CBCentralManager?
     private var scanTimer = Timer() //!< When timer triggers, scanning is stopped
     private var knownDevices = Dictionary<UUID, String>() //!< Map UUID to Serial
@@ -59,14 +59,21 @@ final class BleController: NSObject, CBCentralManagerDelegate {
         }
     }
     
-    func startScan(deviceFound: @escaping (MovesenseDevice) -> (), scanReady: @escaping () -> ()) {
+
+
+    func startScan(deviceFound: @escaping (MovesenseDevice) -> (), scanReady: @escaping () -> (), includeDfu: Bool) {
         if (self.centralManager?.isScanning)! {
             return
         }
         
         self.addDeviceCallback = deviceFound
         
-        self.centralManager?.scanForPeripherals(withServices: MOVESENSE_SERVICES, options:
+        var services = MOVESENSE_SERVICES
+        if (includeDfu) {
+            services.append(MOVESENSE_DFU_SERVICE)
+        }
+        
+        self.centralManager?.scanForPeripherals(withServices: services, options:
             [CBCentralManagerScanOptionAllowDuplicatesKey: true]);
         
         self.scanTimer.invalidate()

--- a/ios/Classes/MdsService.swift
+++ b/ios/Classes/MdsService.swift
@@ -22,13 +22,14 @@ final public class MdsService: NSObject {
     
     /// Start looking for Movesense devices
     public func startScan(_ deviceFound : @escaping (MovesenseDevice) -> (),
-                          _ scanCompleted: @escaping () -> ()) {
+                          _ scanCompleted: @escaping () -> (),
+                          _ includeDfu: Bool) {
             self.bleController.startScan(deviceFound: { device in
                 self.devices[device.serial] = device
                 deviceFound(device)
             },scanReady : {
                 scanCompleted()
-            });
+            }, includeDfu: includeDfu);
     }
     
     /// Stop looking for Movesense devices

--- a/ios/Classes/SwiftMdsflutterPlugin.swift
+++ b/ios/Classes/SwiftMdsflutterPlugin.swift
@@ -57,7 +57,17 @@ public class SwiftMdsflutterPlugin: NSObject, FlutterPlugin, CBCentralManagerDel
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
         case "startScan": do {
-            self.mds.startScan({device in self.handleScannedDevice(device: device)}, {})
+            guard let args = call.arguments else {
+                self.mds.startScan({device in self.handleScannedDevice(device: device)}, {}, false)
+                return
+            }
+            
+            if let myArgs = args as? [String: Any],
+               let includeDfu = myArgs["includeDfu"] as? Bool {
+                self.mds.startScan({device in self.handleScannedDevice(device: device)}, {}, includeDfu)
+            } else {
+                self.mds.startScan({device in self.handleScannedDevice(device: device)}, {}, false)
+            }
         }
         case "stopScan": do {
             self.mds.stopScan()

--- a/lib/Mds.dart
+++ b/lib/Mds.dart
@@ -13,8 +13,9 @@ class Mds {
   /// devices will get UUID as the address parameter. Scanning is terminated
   /// automatically after 60 seconds. Only devices with Movesense services are
   /// returned.
-  static void startScan(void Function(String?, String?) onNewDeviceFound) {
-    MdsImpl().startScan(onNewDeviceFound);
+  static void startScan(void Function(String?, String?) onNewDeviceFound,
+      {bool includeDfu = false}) {
+    MdsImpl().startScan(onNewDeviceFound, includeDfu);
   }
 
   /// Stops the ongoing scan.
@@ -147,8 +148,9 @@ class MdsAsync {
   /// devices will get UUID as the address parameter. Scanning is terminated
   /// automatically after 60 seconds. Only devices with Movesense services are
   /// returned.
-  static void startScan(void Function(String?, String?) onNewDeviceFound) {
-    MdsImpl().startScan(onNewDeviceFound);
+  static void startScan(void Function(String?, String?) onNewDeviceFound,
+      {bool includeDfu = false}) {
+    MdsImpl().startScan(onNewDeviceFound, includeDfu);
   }
 
   /// Stops the ongoing scan.

--- a/lib/internal/MdsImpl.dart
+++ b/lib/internal/MdsImpl.dart
@@ -22,9 +22,10 @@ class MdsImpl {
   Map _serialToAddressMap = Map<String?, String?>();
   void Function(String?, String?)? _newScannedDeviceCb;
 
-  void startScan(void Function(String?, String?) onNewDeviceFound) {
+  void startScan(
+      void Function(String?, String?) onNewDeviceFound, bool includeDfu) {
     _newScannedDeviceCb = onNewDeviceFound;
-    _channel.invokeMethod('startScan', null);
+    _channel.invokeMethod('startScan', {"includeDfu": includeDfu});
   }
 
   void stopScan() {


### PR DESCRIPTION
**Description :**
- This PR adds the DFU Service UUID to the advertising packet when a device is in DFU mode. This allows central devices to discover and filter for peripherals that are ready for a firmware update. 

**Motivation :**
- Since the Movesense API expose an endpoint (System/Mode) to allow putting a sensor in DFU mode, the scan filters should allow to detect sensors in dfu mode this way there is no need for another Bluetooth managing package. 

**Approach**
- This was achieved by adding a DFU specific UUID (0xFE59) which from my researches appear to be the one officially designated for Nordic Semiconductor's DFU Service that Movesense devices are based on.